### PR TITLE
feat: 이벤트리스트 테이블 데이터 생성/업데이트 기능

### DIFF
--- a/src/main/java/ssgssak/ssgpointappevent/SsgPointAppEventApplication.java
+++ b/src/main/java/ssgssak/ssgpointappevent/SsgPointAppEventApplication.java
@@ -2,8 +2,9 @@ package ssgssak.ssgpointappevent;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class SsgPointAppEventApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/application/EventListServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/application/EventListServiceImpl.java
@@ -1,0 +1,49 @@
+package ssgssak.ssgpointappevent.domain.event.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateNewEventListDto;
+import ssgssak.ssgpointappevent.domain.event.dto.UpdateEventListDto;
+import ssgssak.ssgpointappevent.domain.event.entity.EventList;
+import ssgssak.ssgpointappevent.domain.event.infrastructure.EventListRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventListServiceImpl {
+    private final EventListRepository eventListRepository;
+    private final ModelMapper modelMapper;
+
+    private static final DateTimeFormatter stringToDate = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    /*
+    1. 새로운 이벤트 생성
+    2. 이벤트 종료일 변경
+     */
+
+    // 1. 새로운 이벤트 생성
+    public void createEventList(CreateNewEventListDto eventListInfoDto) {
+        log.info("eventListInfoDto : " + eventListInfoDto);
+        EventList newEvent = EventList.builder()
+                .startDate(LocalDate.parse(eventListInfoDto.getStartDate(), stringToDate))
+                .endDate(LocalDate.parse(eventListInfoDto.getEndDate(), stringToDate))
+                .isOver(eventListInfoDto.getIsOver())
+                .eventType(eventListInfoDto.getEventType())
+                .build();
+        eventListRepository.save(newEvent);
+    }
+
+    // 2. 이벤트 종료일 변경
+    public void changeEventListEndDate(UpdateEventListDto updateEventListDto, Long eventListId) {
+        EventList eventList = eventListRepository.findById(eventListId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다."));
+        LocalDate newEndDate = LocalDate.parse(updateEventListDto.getEndDate(), stringToDate);
+        eventList.changeEndDate(newEndDate);
+        eventListRepository.save(eventList);
+    }
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateNewEventListDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateNewEventListDto.java
@@ -1,0 +1,20 @@
+package ssgssak.ssgpointappevent.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssgssak.ssgpointappevent.domain.event.entity.EventType;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateNewEventListDto {
+    private String startDate;
+    private String endDate;
+    private EventType eventType;
+    private Boolean isOver;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/UpdateEventListDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/UpdateEventListDto.java
@@ -1,0 +1,17 @@
+package ssgssak.ssgpointappevent.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UpdateEventListDto {
+    private String endDate;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/DrawingEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/DrawingEvent.java
@@ -1,0 +1,31 @@
+package ssgssak.ssgpointappevent.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class DrawingEvent {
+    @Id
+    private Long eventListId;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "event_list_id")
+    private EventList eventList;
+
+    @Column(nullable = false, name = "title")
+    private String title;
+
+    @Column(nullable = false, name = "title_image_url")
+    private String titleImageUrl;
+
+    @Column(nullable = false, name = "contents_image_url")
+    private String contentsImageUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventList.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventList.java
@@ -1,0 +1,40 @@
+package ssgssak.ssgpointappevent.domain.event.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EventList {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Column(nullable = false, name = "start_date")
+    private LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Column(nullable = false, name = "end_date")
+    private LocalDate endDate;
+
+    @Column(nullable = false, name = "event_type")
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+
+    @Column(nullable = false, name = "is_over")
+    private Boolean isOver;
+
+    public void changeEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventType.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventType.java
@@ -1,0 +1,6 @@
+package ssgssak.ssgpointappevent.domain.event.entity;
+
+public enum EventType {
+    INFORMATION, DRAWING, REDIRECTION
+
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/InformationTypeEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/InformationTypeEvent.java
@@ -1,0 +1,31 @@
+package ssgssak.ssgpointappevent.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class InformationTypeEvent { // 조회형 이벤트
+    // 식별 관계 매핑
+    @Id
+    private Long eventListId;
+    @MapsId // EventList의 PK를 FK로 사용(EventListId로 매핑)
+    @OneToOne
+    @JoinColumn(name = "event_list_id")
+    private EventList eventList;
+
+    @Column(nullable = false, name = "title")
+    private String title;
+
+    @Column(nullable = false, name = "title_image url")
+    private String titleImageUrl;
+
+    @Column(nullable = false, name = "contents_image url")
+    private String contentsImageUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/RedirectionEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/RedirectionEvent.java
@@ -1,0 +1,34 @@
+package ssgssak.ssgpointappevent.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RedirectionEvent { // 페이지 이동형 이벤트
+    // 식별 관계 매핑
+    @Id
+    private Long eventListId;
+    @MapsId // EventList의 PK를 FK로 사용(EventListId로 매핑)
+    @OneToOne
+    @JoinColumn(name = "event_list_id")
+    private EventList eventList;
+
+    @Column(nullable = false, name = "title")
+    private String title;
+
+    @Column(nullable = false, name = "title_image_url")
+    private String titleImageUrl;
+
+    @Column(nullable = false, name = "contents_image_url")
+    private String contentsImageUrl;
+
+    @Column(nullable = false, name = "redirection_url")
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/infrastructure/EventListRepository.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/infrastructure/EventListRepository.java
@@ -1,0 +1,8 @@
+package ssgssak.ssgpointappevent.domain.event.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ssgssak.ssgpointappevent.domain.event.entity.EventList;
+
+public interface EventListRepository extends JpaRepository<EventList, Long> {
+    
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventListController.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventListController.java
@@ -1,0 +1,39 @@
+package ssgssak.ssgpointappevent.domain.event.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.web.bind.annotation.*;
+import ssgssak.ssgpointappevent.domain.event.application.EventListServiceImpl;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateNewEventListDto;
+import ssgssak.ssgpointappevent.domain.event.dto.UpdateEventListDto;
+import ssgssak.ssgpointappevent.domain.event.vo.CreateNewEventListVo;
+import ssgssak.ssgpointappevent.domain.event.vo.UpdateEventListVo;
+
+@RestController
+@RequestMapping("/api/v1/event/event-list")
+@RequiredArgsConstructor
+public class EventListController {
+    private final EventListServiceImpl eventListService;
+    private final ModelMapper modelMapper;
+
+    /*
+    아래는 어드민 API
+    // todo: 관리자 인증 방식 정하기
+    1. 새로운 이벤트 생성
+    2. 이벤트 정보수정(종료일 변경)
+    */
+
+    // 1. 새로운 이벤트 생성
+    @PostMapping("/admin/create")
+    public void createEventList(@RequestBody CreateNewEventListVo createNewEventListVo){
+        CreateNewEventListDto eventListInfoDto = modelMapper.map(createNewEventListVo, CreateNewEventListDto.class);
+        eventListService.createEventList(eventListInfoDto);
+    }
+
+    // 2. 이벤트 정보수정(종료일 변경)
+    @PutMapping("/admin/update/{eventListId}")
+    public void updateEventList(@RequestBody UpdateEventListVo updateEventListVo, @PathVariable Long eventListId){
+        UpdateEventListDto updateEventListDto = modelMapper.map(updateEventListVo, UpdateEventListDto.class);
+        eventListService.changeEventListEndDate(updateEventListDto, eventListId);
+    }
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventTypeController.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventTypeController.java
@@ -1,0 +1,12 @@
+package ssgssak.ssgpointappevent.domain.event.presentation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/event/event-type")
+@Slf4j
+public class EventTypeController {
+
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/CreateNewEventListVo.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/CreateNewEventListVo.java
@@ -1,0 +1,14 @@
+package ssgssak.ssgpointappevent.domain.event.vo;
+
+import lombok.Getter;
+import ssgssak.ssgpointappevent.domain.event.entity.EventType;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateNewEventListVo {
+    private String startDate;
+    private String endDate;
+    private EventType eventType;
+    private Boolean isOver;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/UpdateEventListVo.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/UpdateEventListVo.java
@@ -1,0 +1,14 @@
+package ssgssak.ssgpointappevent.domain.event.vo;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/*
+이벤트 시작일, 종료일, 이벤트타입 중 수정 가능한 것은 종료일 뿐이기 때문에 종료일만 받는다.
+종료 여부는 관리자가 직접 수정하는 것이 아닌 종료일이 임박하면 따로 종료처리하는 로직 구현.
+ */
+@Getter
+public class UpdateEventListVo {
+    private String endDate;
+}


### PR DESCRIPTION
# 변경점 👍
이벤트리스트 중간테이블 데이터 생성/업데이트(이벤트 종료일 변경) 기능 추가
 
# 스크린샷 🖼
1. 데이터 생성
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/88362026-a790-4c8d-accb-a835c75c3e22)
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/0768af8a-97c1-42d9-a405-9695535c5a51)

2. 이벤트 종료일 수정
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/0e88b33b-4c05-4d59-9a88-76f9c8ec5f29)
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/fad9e072-314c-4081-b984-26a31ee5c626)

# 비고 ✏
일단 어드민 api부터 만들었습니다. 어드민 쪽은 api가 어떻게 돌아가는지 알 방법이 없기 때문에 제 생각대로 계속 만들어 볼 것 같아요.
이벤트 수정에서 수정가능한 필드는 이벤트 종료일로 제한하고 그 외의 필드는 수정기능을 넣지 않는게 좋을 것 같습니다(이벤트 이름, 타입, 시작일이 바뀔 이유는 없을 것 같고, 이벤트를 조기종료하거나 기간연장을 하는 경우를 고려).
이해가 가지 않는 필드가 있으면 erd 참고해주세요. 필드명이 좀 바뀐게 있습니다.