### PR TITLE
feat: 페이지 이동 이벤트 생성, 수정, 조회 기능

### DIFF
--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/application/EventListServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/application/EventListServiceImpl.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-import ssgssak.ssgpointappevent.domain.event.dto.CreateNewEventListDto;
+import org.springframework.transaction.annotation.Transactional;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateEventListDto;
 import ssgssak.ssgpointappevent.domain.event.dto.ReadEventsDto;
 import ssgssak.ssgpointappevent.domain.event.dto.UpdateEventListDto;
 import ssgssak.ssgpointappevent.domain.event.entity.EventList;
@@ -16,6 +17,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class EventListServiceImpl {
     private final EventListRepository eventListRepository;
     private final ModelMapper modelMapper;
@@ -26,7 +28,7 @@ public class EventListServiceImpl {
      */
 
     // 1. 새로운 이벤트 생성
-    public void createEventList(CreateNewEventListDto eventListInfoDto) {
+    public void createEventList(CreateEventListDto eventListInfoDto) {
         log.info("eventListInfoDto : " + eventListInfoDto);
         EventList newEvent = modelMapper.map(eventListInfoDto, EventList.class);
         eventListRepository.save(newEvent);
@@ -37,10 +39,10 @@ public class EventListServiceImpl {
         EventList eventList = eventListRepository.findById(eventListId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다."));
         eventList.changeEndDate(updateEventListDto.getEndDate());
-        eventListRepository.save(eventList);
     }
 
     // 3. 진행 이벤트 최신순으로 받아오기
+    @Transactional(readOnly = true)
     public ReadEventsDto getLatestEvents() {
         List<EventList> events = eventListRepository.findAllByIsOverOrderByStartDateDesc(false);
         log.info("events : " + events);
@@ -49,6 +51,7 @@ public class EventListServiceImpl {
     }
 
     // 4. 진행 이벤트 마감임박순으로 받아오기
+    @Transactional(readOnly = true)
     public ReadEventsDto getImminentEvents() {
         List<EventList> events = eventListRepository.findAllByIsOverOrderByEndDateAsc(false);
         log.info("events : " + events);

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/application/InformationTypeEventServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/application/InformationTypeEventServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ssgssak.ssgpointappevent.domain.event.dto.CreateInformationTypeEventDto;
 import ssgssak.ssgpointappevent.domain.event.dto.GetInformationTypeEventDto;
 import ssgssak.ssgpointappevent.domain.event.dto.UpdateInformationTypeEventDto;
@@ -13,6 +14,7 @@ import ssgssak.ssgpointappevent.domain.event.infrastructure.InformationTypeEvent
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class InformationTypeEventServiceImpl {
     private final InformationTypeEventRepository informationTypeEventRepository;
     private final ModelMapper modelMapper;
@@ -30,6 +32,7 @@ public class InformationTypeEventServiceImpl {
     }
 
     // 2. 이벤트 조회
+    @Transactional(readOnly = true)
     public GetInformationTypeEventDto getInformationTypeEvent(Long eventListId){
         InformationTypeEvent informationTypeEvent = informationTypeEventRepository.findByEventListId(eventListId);
         return modelMapper.map(informationTypeEvent, GetInformationTypeEventDto.class);
@@ -38,11 +41,10 @@ public class InformationTypeEventServiceImpl {
     // 3. 이벤트 정보 변경(이벤트 이름, 이미지 변경)
     public void updateInformationTypeEvent(UpdateInformationTypeEventDto updateInformationTypeEventDto, Long eventListId){
         InformationTypeEvent informationTypeEvent = informationTypeEventRepository.findByEventListId(eventListId);
-        InformationTypeEvent updatedInformationTypeEvent = informationTypeEvent.toBuilder()
-                .title(updateInformationTypeEventDto.getTitle())
-                .titleImageUrl(updateInformationTypeEventDto.getTitleImageUrl())
-                .contentsImageUrl(updateInformationTypeEventDto.getContentsImageUrl())
-                .build();
-        informationTypeEventRepository.save(updatedInformationTypeEvent);
+        informationTypeEvent.updateInformationTypeEvent(
+                updateInformationTypeEventDto.getTitle(),
+                updateInformationTypeEventDto.getTitleImageUrl(),
+                updateInformationTypeEventDto.getContentsImageUrl()
+        );
     }
 }

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/application/RedirectionEventServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/application/RedirectionEventServiceImpl.java
@@ -1,0 +1,50 @@
+package ssgssak.ssgpointappevent.domain.event.application;
+
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.dto.GetRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.dto.UpdateRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.entity.RedirectionEvent;
+import ssgssak.ssgpointappevent.domain.event.infrastructure.RedirectionEventRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class RedirectionEventServiceImpl {
+    private final RedirectionEventRepository redirectionEventRepository;
+    private final ModelMapper modelMapper;
+    /*
+    1. 새로운 이벤트 생성
+    2. 이벤트 정보 변경(이벤트 이름, 이미지 변경)
+    3. 이벤트 정보 조회
+     */
+
+    // 1. 새로운 이벤트 생성
+    public void createRedirectionEvent(CreateRedirectionEventDto createRedirectionEventDto) {
+        RedirectionEvent redirectionEvent = modelMapper.map(createRedirectionEventDto, RedirectionEvent.class);
+        redirectionEventRepository.save(redirectionEvent);
+    }
+
+    // 2. 이벤트 정보 변경
+    public void updateRedirectionEvent(UpdateRedirectionEventDto updateRedirectionEventDto, Long eventListId) {
+        RedirectionEvent redirectionEvent = redirectionEventRepository.findByEventListId(eventListId);
+        redirectionEvent.updateRedirectionEvent(
+                updateRedirectionEventDto.getTitle(),
+                updateRedirectionEventDto.getTitleImageUrl(),
+                updateRedirectionEventDto.getRedirectionUrl(),
+                updateRedirectionEventDto.getContentsImageUrl()
+        );
+    }
+
+    // 3. 이벤트 정보 조회
+    @Transactional(readOnly = true)
+    public GetRedirectionEventDto getRedirectionEvent(Long eventListId) {
+        RedirectionEvent redirectionEvent = redirectionEventRepository.findByEventListId(eventListId);
+        return modelMapper.map(redirectionEvent, GetRedirectionEventDto.class);
+    }
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateEventListDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateEventListDto.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class CreateNewEventListDto {
+public class CreateEventListDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private EventType eventType;

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateRedirectionEventDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/CreateRedirectionEventDto.java
@@ -1,0 +1,18 @@
+package ssgssak.ssgpointappevent.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateRedirectionEventDto {
+    private Long eventListId;
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/GetRedirectionEventDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/GetRedirectionEventDto.java
@@ -1,0 +1,17 @@
+package ssgssak.ssgpointappevent.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class GetRedirectionEventDto {
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/UpdateRedirectionEventDto.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/dto/UpdateRedirectionEventDto.java
@@ -1,0 +1,17 @@
+package ssgssak.ssgpointappevent.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateRedirectionEventDto {
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/DrawingEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/DrawingEvent.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@DynamicUpdate
 public class DrawingEvent {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventList.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/EventList.java
@@ -3,6 +3,7 @@ package ssgssak.ssgpointappevent.domain.event.entity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Getter
 @ToString
+@DynamicUpdate
 public class EventList {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/InformationTypeEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/InformationTypeEvent.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Builder(toBuilder = true)
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate
 public class InformationTypeEvent { // 조회형 이벤트
     // 식별 관계 매핑
     @Id
@@ -28,4 +30,10 @@ public class InformationTypeEvent { // 조회형 이벤트
 
     @Column(nullable = false, name = "contents_image url")
     private String contentsImageUrl;
+
+    public void updateInformationTypeEvent(String title, String titleImageUrl, String contentsImageUrl){
+        this.title = title;
+        this.titleImageUrl = titleImageUrl;
+        this.contentsImageUrl = contentsImageUrl;
+    }
 }

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/RedirectionEvent.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/entity/RedirectionEvent.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate
 public class RedirectionEvent { // 페이지 이동형 이벤트
     // 식별 관계 매핑
     @Id
@@ -31,4 +33,11 @@ public class RedirectionEvent { // 페이지 이동형 이벤트
 
     @Column(nullable = false, name = "redirection_url")
     private String redirectionUrl;
+
+    public void updateRedirectionEvent(String title, String titleImageUrl, String contentsImageUrl, String redirectionUrl) {
+        this.title = title;
+        this.titleImageUrl = titleImageUrl;
+        this.contentsImageUrl = contentsImageUrl;
+        this.redirectionUrl = redirectionUrl;
+    }
 }

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/infrastructure/RedirectionEventRepository.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/infrastructure/RedirectionEventRepository.java
@@ -1,0 +1,10 @@
+package ssgssak.ssgpointappevent.domain.event.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ssgssak.ssgpointappevent.domain.event.entity.RedirectionEvent;
+
+@Repository
+public interface RedirectionEventRepository extends JpaRepository<RedirectionEvent, Long> {
+    RedirectionEvent findByEventListId(Long eventListId);
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventListController.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/EventListController.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ssgssak.ssgpointappevent.domain.event.application.EventListServiceImpl;
-import ssgssak.ssgpointappevent.domain.event.dto.CreateNewEventListDto;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateEventListDto;
 import ssgssak.ssgpointappevent.domain.event.dto.ReadEventsDto;
 import ssgssak.ssgpointappevent.domain.event.dto.UpdateEventListDto;
 import ssgssak.ssgpointappevent.domain.event.vo.CreateEventListVo;
@@ -32,7 +32,7 @@ public class EventListController {
     // 1. 새로운 이벤트 생성
     @PostMapping("/admin")
     public void createEventList(@RequestBody CreateEventListVo createNewEventListVo){
-        CreateNewEventListDto eventListInfoDto = modelMapper.map(createNewEventListVo, CreateNewEventListDto.class);
+        CreateEventListDto eventListInfoDto = modelMapper.map(createNewEventListVo, CreateEventListDto.class);
         eventListService.createEventList(eventListInfoDto);
     }
 

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/RedirectionEventController.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/presentation/RedirectionEventController.java
@@ -1,0 +1,57 @@
+package ssgssak.ssgpointappevent.domain.event.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ssgssak.ssgpointappevent.domain.event.application.RedirectionEventServiceImpl;
+import ssgssak.ssgpointappevent.domain.event.dto.CreateRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.dto.GetRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.dto.UpdateRedirectionEventDto;
+import ssgssak.ssgpointappevent.domain.event.vo.CreateRedirectionEventVo;
+import ssgssak.ssgpointappevent.domain.event.vo.GetRedirectionEventVo;
+import ssgssak.ssgpointappevent.domain.event.vo.UpdateRedirectionEventVo;
+
+@RestController
+@RequestMapping("/api/v1/event/redirection")
+@RequiredArgsConstructor
+public class RedirectionEventController { // 페이지 이동 이벤트
+    private final RedirectionEventServiceImpl redirectionEventService;
+    private final ModelMapper modelMapper;
+    /*
+    아래는 어드민 API
+    1. 이벤트 생성
+    2. 이벤트 정보 변경(이벤트 이름, 이미지 변경)
+     */
+
+    // 1. 이벤트 생성
+    @PostMapping("/admin")
+    public void createRedirectionEvent(@RequestBody CreateRedirectionEventVo createRedirectionEventVo){
+        CreateRedirectionEventDto createRedirectionEventDto = modelMapper.map(createRedirectionEventVo,
+                CreateRedirectionEventDto.class);
+        redirectionEventService.createRedirectionEvent(createRedirectionEventDto);
+    }
+
+    // 2. 이벤트 정보 변경
+    @PutMapping("/admin")
+    public void updateRedirectionEvent(@RequestBody UpdateRedirectionEventVo updateRedirectionEventVo,
+                                       @RequestParam(name = "id") Long eventListId){
+        UpdateRedirectionEventDto updateRedirectionEventDto = modelMapper.map(updateRedirectionEventVo,
+                UpdateRedirectionEventDto.class);
+        redirectionEventService.updateRedirectionEvent(updateRedirectionEventDto, eventListId);
+    }
+
+    /*
+    아래는 유저 API
+    1. 이벤트 조회
+     */
+
+    // 1. 이벤트 조회
+    @GetMapping("")
+    public ResponseEntity<GetRedirectionEventVo> getRedirectionEvent(@RequestParam(name = "id") Long eventListId) {
+        GetRedirectionEventDto getRedirectionEventDto = redirectionEventService.getRedirectionEvent(eventListId);
+        GetRedirectionEventVo getRedirectionEventVo = modelMapper.map(getRedirectionEventDto, GetRedirectionEventVo.class);
+        return new ResponseEntity<>(getRedirectionEventVo, HttpStatus.OK);
+    }
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/CreateRedirectionEventVo.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/CreateRedirectionEventVo.java
@@ -1,0 +1,12 @@
+package ssgssak.ssgpointappevent.domain.event.vo;
+
+import lombok.Getter;
+
+@Getter
+public class CreateRedirectionEventVo {
+    private Long eventListId;
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/GetRedirectionEventVo.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/GetRedirectionEventVo.java
@@ -1,0 +1,17 @@
+package ssgssak.ssgpointappevent.domain.event.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetRedirectionEventVo {
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}

--- a/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/UpdateRedirectionEventVo.java
+++ b/src/main/java/ssgssak/ssgpointappevent/domain/event/vo/UpdateRedirectionEventVo.java
@@ -1,0 +1,11 @@
+package ssgssak.ssgpointappevent.domain.event.vo;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateRedirectionEventVo {
+    private String title;
+    private String titleImageUrl;
+    private String contentsImageUrl;
+    private String redirectionUrl;
+}


### PR DESCRIPTION
# 변경점 👍
1. 페이지 이동 이벤트 생성, 수정, 조회 기능 추가하였습니다.

# 리팩토링 🛠
1. @Transactional을 각 서비스단에 추가하였습니다.
2. toBuilder를 엔티티 내의 업데이트 메서드로 대체하였습니다.

# 스크린샷 🖼
1. Create
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/473c4277-5727-4bde-a192-2e2a41b91edd)

2. Read
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/612ba6b5-6769-4ef1-a3f0-d15fe33f1217)

3. Update
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/e0329534-7d3e-450d-bf91-4a3d1ea1dce6)
![image](https://github.com/ssg-ssak/ssg-ssak-BE-event/assets/77543446/244b65fb-4bb2-404b-86ea-da1ca500cbca)